### PR TITLE
add lazy loading for images

### DIFF
--- a/reps_event_app/ios/Flutter/flutter_export_environment.sh
+++ b/reps_event_app/ios/Flutter/flutter_export_environment.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# This is a generated file; do not edit or check into version control.
+export "FLUTTER_ROOT=/Users/enzoftware/Development/flutter"
+export "FLUTTER_APPLICATION_PATH=/Users/enzoftware/Projects/Hacktoberfest2019/Reps-Events-Mobile/reps_event_app"
+export "FLUTTER_TARGET=lib/main.dart"
+export "FLUTTER_BUILD_DIR=build"
+export "SYMROOT=${SOURCE_ROOT}/../build/ios"
+export "FLUTTER_FRAMEWORK_DIR=/Users/enzoftware/Development/flutter/bin/cache/artifacts/engine/ios"
+export "FLUTTER_BUILD_NAME=1.0.0"
+export "FLUTTER_BUILD_NUMBER=1"

--- a/reps_event_app/lib/ui/reps.dart
+++ b/reps_event_app/lib/ui/reps.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import "package:flutter/material.dart";
 import 'package:provider/provider.dart';
 import 'package:reps_event_app/models/reps_model.dart';
@@ -115,11 +116,16 @@ class _RepsState extends State<Reps> {
                     child: ListTile(
                       contentPadding: EdgeInsets.all(8.0),
                       leading: ClipRRect(
-                          clipBehavior: Clip.antiAlias,
-                          borderRadius: BorderRadius.circular(50.0),
-                          child: Image.network(
-                            snapshot.data[index].avatar_url,
-                          )),
+                        clipBehavior: Clip.antiAlias,
+                        borderRadius: BorderRadius.circular(50.0),
+                        child: CachedNetworkImage(
+                          imageUrl: snapshot.data[index].avatar_url,
+                          placeholder: (context, url) =>
+                              CircularProgressIndicator(),
+                          errorWidget: (context, url, error) =>
+                              Icon(Icons.error),
+                        ),
+                      ),
                       onTap: () {
                         Navigator.pushNamed(context, RepsDetails.route,
                             arguments: snapshot.data[index]);
@@ -139,11 +145,14 @@ class _RepsState extends State<Reps> {
                 child: ListTile(
                 contentPadding: EdgeInsets.all(8.0),
                 leading: ClipRRect(
-                    clipBehavior: Clip.antiAlias,
-                    borderRadius: BorderRadius.circular(50.0),
-                    child: Image.network(
-                      snapshot.data[index].avatar_url,
-                    )),
+                  clipBehavior: Clip.antiAlias,
+                  borderRadius: BorderRadius.circular(50.0),
+                  child: CachedNetworkImage(
+                    imageUrl: snapshot.data[index].avatar_url,
+                    placeholder: (context, url) => CircularProgressIndicator(),
+                    errorWidget: (context, url, error) => Icon(Icons.error),
+                  ),
+                ),
                 onTap: () {
                   Navigator.pushNamed(context, RepsDetails.route,
                       arguments: snapshot.data[index]);

--- a/reps_event_app/lib/ui/repsDetails.dart
+++ b/reps_event_app/lib/ui/repsDetails.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import "package:flutter/material.dart";
 import 'package:reps_event_app/models/reps_model.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
@@ -25,9 +26,14 @@ class _RepsDetailsState extends State<RepsDetails> {
               mainAxisAlignment: MainAxisAlignment.start,
               children: <Widget>[
                 ClipRRect(
-                    clipBehavior: Clip.antiAlias,
-                    borderRadius: BorderRadius.circular(80.0),
-                    child: Image.network(widget.reps.avatar_url, scale: 0.6)),
+                  clipBehavior: Clip.antiAlias,
+                  borderRadius: BorderRadius.circular(80.0),
+                  child: CachedNetworkImage(
+                    imageUrl: widget.reps.avatar_url,
+                    placeholder: (context, url) => CircularProgressIndicator(),
+                    errorWidget: (context, url, error) => Icon(Icons.error),
+                  ),
+                ),
                 SizedBox(height: 8),
                 titleText(widget.reps.display_name)
               ],

--- a/reps_event_app/pubspec.lock
+++ b/reps_event_app/pubspec.lock
@@ -23,7 +23,7 @@ packages:
     source: hosted
     version: "1.0.5"
   cached_network_image:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: cached_network_image
       url: "https://pub.dartlang.org"

--- a/reps_event_app/pubspec.yaml
+++ b/reps_event_app/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
   shared_preferences:
   html_unescape:
   flare_flutter: ^1.5.9
+  cached_network_image: ^1.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION

Fixes #36  <!-- If you are fixing an issue, provide the issue number -->

**Summary**: 
Add lazy loading for network images.

**Screenshots for the change**: 
<!-- If you are making some UI changes, it is a good idea to share screenshots or links -->
Before: 
- Blank space while network image is loading

After: 
- [While network image is loading](https://ibb.co/xs7TVnR)
- [When image is loaded](https://ibb.co/4gW5hP8)
